### PR TITLE
Proof verification reset bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-verifier",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-verifier",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-verifier",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Front-end for Veritable verifiers",
   "author": "Digital Catapult (https://www.digicatapult.org.uk/)",
   "license": "Apache-2.0",

--- a/src/components/ColumnLeft/ColumnLeftWrap/ColumnLeftWrap.js
+++ b/src/components/ColumnLeft/ColumnLeftWrap/ColumnLeftWrap.js
@@ -10,13 +10,12 @@ import usePostPresentProofRecordsVerifyPresentation from '../../../interface/hoo
 export default function ColumnLeftWrap({ origin, connections }) {
   const now = new Date()
   const tomorrow = new Date(+now + 86400000)
+  const defaultValidity = tomorrow.toISOString().split('T')[0]
 
   const [selectedVersion, setSelectedVersion] = useState('')
   const [selectedConnection, setSelectedConnection] = useState('')
 
-  const [selectedValidity, setSelectedValidity] = useState(
-    tomorrow.toISOString().split('T')[0]
-  )
+  const [selectedValidity, setSelectedValidity] = useState(defaultValidity)
   const [isValidityLocked, setIsValidityLocked] = useState(true)
   const [selectedId, setSelectedId] = useState('')
   const [selectedName, setSelectedName] = useState('')
@@ -43,11 +42,12 @@ export default function ColumnLeftWrap({ origin, connections }) {
   const activatedResetHandler = () => {
     setSelectedConnection('')
     setSelectedVersion('')
-    setSelectedValidity('')
+    setSelectedValidity(defaultValidity)
     setSelectedId('')
     setSelectedName('')
     setSelectedSurname('')
     setSelectedType('')
+    setSelectedExchange('')
   }
 
   const chooseVersionHandler = (e) => {


### PR DESCRIPTION
Fixes a bug where attempting to perform a second proof verification flow fails. This is because you cannot select the correct proof exchange id to verify as the form did not reset correctly

### What
For story - [F2P-76](https://digicatapult.atlassian.net/browse/F2P-76)
